### PR TITLE
Remove inadmissible states from state space

### DIFF
--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -105,6 +105,13 @@ def pyth_create_state_space(model_params):
                             if (choice_lagged == 1) and (exp_p == 0):
                                 continue
 
+                            # If an individual has always been employed,
+                            # she cannot have non-employment (0) as lagged choice
+                            if (choice_lagged == 0) and (
+                                exp_f + exp_p == period - educ_years
+                            ):
+                                continue
+
                             # Check for duplicate states
                             if (
                                 mapping_states_index[

--- a/soepy/test/test_unit.py
+++ b/soepy/test/test_unit.py
@@ -1,5 +1,6 @@
-import numpy as np
 from collections import namedtuple
+
+import numpy as np
 
 from soepy.python.shared.shared_auxiliary import calculate_consumption_utilities
 from soepy.python.shared.shared_auxiliary import calculate_total_utilities

--- a/soepy/test/test_unit.py
+++ b/soepy/test/test_unit.py
@@ -160,20 +160,18 @@ def test5():
     np.testing.assert_array_equal(states_number_period, [1, 4, 13, 30])
 
     # Control that the states are correct
-    states_true = np.full((576, 4), MISSING_INT)
+    states_true = np.full((4, 576, 4), MISSING_INT)
 
-    # Period zero
-    states_true[0] = [10, 0, 0, 0]
-    states_period0 = states_all[0, :, :]
-    np.testing.assert_array_equal(states_true, states_period0)
+    states_true[0, 0, :] = [10, 0, 0, 0]
 
-    # Period one
-    states_true[0:4] = [[10, 0, 0, 0], [10, 1, 1, 0], [10, 2, 0, 1], [11, 0, 0, 0]]
-    states_period1 = states_all[1, :, :]
-    np.testing.assert_array_equal(states_true, states_period1)
+    states_true[1, 0:4, :] = [
+        [10, 0, 0, 0],
+        [10, 1, 1, 0],
+        [10, 2, 0, 1],
+        [11, 0, 0, 0],
+    ]
 
-    # Period two
-    states_true[0:13] = [
+    states_true[2, 0:13, :] = [
         [10, 0, 0, 0],
         [10, 0, 1, 0],
         [10, 1, 1, 0],
@@ -188,11 +186,8 @@ def test5():
         [11, 2, 0, 1],
         [12, 0, 0, 0],
     ]
-    states_period2 = states_all[2, :, :]
-    np.testing.assert_array_equal(states_true, states_period2)
 
-    # Period three
-    states_true[0:30] = [
+    states_true[3, 0:30, :] = [
         [10, 0, 0, 0],
         [10, 0, 1, 0],
         [10, 1, 1, 0],
@@ -224,8 +219,8 @@ def test5():
         [12, 1, 1, 0],
         [12, 2, 0, 1],
     ]
-    states_period3 = states_all[3, :, :]
-    np.testing.assert_array_equal(states_true, states_period3)
+
+    np.testing.assert_array_equal(states_true, states_all)
 
 
 cleanup()

--- a/soepy/test/test_unit.py
+++ b/soepy/test/test_unit.py
@@ -1,11 +1,14 @@
 import numpy as np
+from collections import namedtuple
 
 from soepy.python.shared.shared_auxiliary import calculate_consumption_utilities
 from soepy.python.shared.shared_auxiliary import calculate_total_utilities
 from soepy.python.shared.shared_auxiliary import calculate_wage_systematic
 from soepy.python.shared.shared_auxiliary import calculate_period_wages
+from soepy.python.solve.solve_auxiliary import pyth_create_state_space
 from soepy.python.pre_processing.model_processing import read_init_file
 from soepy.python.shared.shared_auxiliary import draw_disturbances
+from soepy.python.shared.shared_constants import MISSING_INT
 from soepy.python.simulate.simulate_python import simulate
 from soepy.test.random_init import random_init
 from soepy.test.random_init import read_init_file2
@@ -141,6 +144,87 @@ def test4():
         df = simulate("test.soepy.yml")
 
         np.testing.assert_array_equal(df.shape[0], constr["AGENTS"] * constr["PERIODS"])
+
+
+def test5():
+    """This test ensures that the state space creation generates the correct admissible
+    state space points for the first 4 periods."""
+
+    model_params = namedtuple("model_params", "num_periods educ_range educ_min")
+    model_params = model_params(4, 3, 10)
+
+    states_all, states_number_period, _, _ = pyth_create_state_space(model_params)
+
+    # Control for correct number of states in each period.
+    np.testing.assert_array_equal(states_number_period, [1, 4, 13, 30])
+
+    # Control that the states are correct
+    states_true = np.full((576, 4), MISSING_INT)
+
+    # Period zero
+    states_true[0] = [10, 0, 0, 0]
+    states_period0 = states_all[0, :, :]
+    np.testing.assert_array_equal(states_true, states_period0)
+
+    # Period one
+    states_true[0:4] = [[10, 0, 0, 0], [10, 1, 1, 0], [10, 2, 0, 1], [11, 0, 0, 0]]
+    states_period1 = states_all[1, :, :]
+    np.testing.assert_array_equal(states_true, states_period1)
+
+    # Period two
+    states_true[0:13] = [
+        [10, 0, 0, 0],
+        [10, 0, 1, 0],
+        [10, 1, 1, 0],
+        [10, 1, 2, 0],
+        [10, 0, 0, 1],
+        [10, 2, 0, 1],
+        [10, 1, 1, 1],
+        [10, 2, 1, 1],
+        [10, 2, 0, 2],
+        [11, 0, 0, 0],
+        [11, 1, 1, 0],
+        [11, 2, 0, 1],
+        [12, 0, 0, 0],
+    ]
+    states_period2 = states_all[2, :, :]
+    np.testing.assert_array_equal(states_true, states_period2)
+
+    # Period three
+    states_true[0:30] = [
+        [10, 0, 0, 0],
+        [10, 0, 1, 0],
+        [10, 1, 1, 0],
+        [10, 0, 2, 0],
+        [10, 1, 2, 0],
+        [10, 1, 3, 0],
+        [10, 0, 0, 1],
+        [10, 2, 0, 1],
+        [10, 0, 1, 1],
+        [10, 1, 1, 1],
+        [10, 2, 1, 1],
+        [10, 1, 2, 1],
+        [10, 2, 2, 1],
+        [10, 0, 0, 2],
+        [10, 2, 0, 2],
+        [10, 1, 1, 2],
+        [10, 2, 1, 2],
+        [10, 2, 0, 3],
+        [11, 0, 0, 0],
+        [11, 0, 1, 0],
+        [11, 1, 1, 0],
+        [11, 1, 2, 0],
+        [11, 0, 0, 1],
+        [11, 2, 0, 1],
+        [11, 1, 1, 1],
+        [11, 2, 1, 1],
+        [11, 2, 0, 2],
+        [12, 0, 0, 0],
+        [12, 1, 1, 0],
+        [12, 2, 0, 1],
+    ]
+    states_period3 = states_all[3, :, :]
+    np.testing.assert_array_equal(states_true, states_period3)
 
 
 cleanup()


### PR DESCRIPTION
The issue that is addressed here is that the state space contained state space points that are inadmissible since they do not obey time constraints. E.g., in period 2, the state [10, 0, 1, 1] is not admissible since the agent cannot have has one year of part-time work, one year of full-time work and non-employment in the previous (3 activities) in 2 periods.

As @peisenha presumed, the regression tests are not affected by the change. Both the calculations of the flow utility and the continuation values do (luckily) not take the inadmissible ("wrong") states as inputs.

 