### PR TITLE
Numbanize backward induction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,9 +4,9 @@ We want to collect some basic information on the project's next steps.
 
 ## CURRENT
 
-* We are opening a new PR code_cleanup to address the issues collected in our Github [project 1](https://github.com/OpenSourceEconomics/soepy/projects/1).
-* We are working on the SMM interface at Boryana's [repo](https://github.com/boryana-ilieva/smm_soepy) which will provide the adapter classes for the SMM estimation that we want to integrate into the package itself.
+* We are ensuring model robustness for specifications with a higher number of periods.
 
 ## UPCOMING
 
-* We need to address performance issues by working with NUMBA.
+* We are working on the SMM interface at Boryana's [repo](https://github.com/boryana-ilieva/smm_soepy) which will provide the adapter classes for the SMM estimation that we want to integrate into the package itself.
+* We will construct moments from the SOEP dataset to base SMM estimation on.

--- a/soepy/python/shared/shared_auxiliary.py
+++ b/soepy/python/shared/shared_auxiliary.py
@@ -159,34 +159,3 @@ def calculate_total_utilities(model_params, consumption_utilities):
 
     # Return function output
     return total_utilities
-
-
-def calculate_continuation_values(
-    model_params, indexer, period, periods_emax, educ_years_idx, exp_p, exp_f
-):
-    """Obtain continuation values for each of the choices."""
-
-    # Initialize container for continuation values
-    continuation_values = np.full(NUM_CHOICES, np.nan)
-
-    if period != (model_params.num_periods - 1):
-
-        # Choice: Non-employment
-        # Create index for extracting the continuation value
-        future_idx = indexer[period + 1, educ_years_idx, 0, exp_p, exp_f]
-        # Extract continuation value
-        continuation_values[0] = periods_emax[future_idx]
-
-        # Choice: Part-time
-        future_idx = indexer[period + 1, educ_years_idx, 1, exp_p + 1, exp_f]
-        continuation_values[1] = periods_emax[future_idx]
-
-        # Choice: Full-time
-        future_idx = indexer[period + 1, educ_years_idx, 2, exp_p, exp_f + 1]
-        continuation_values[2] = periods_emax[future_idx]
-
-    else:
-        continuation_values = np.full(NUM_CHOICES, 0.0)
-
-    # Return function output
-    return continuation_values

--- a/soepy/python/shared/shared_auxiliary.py
+++ b/soepy/python/shared/shared_auxiliary.py
@@ -108,7 +108,7 @@ def calculate_period_wages(model_params, states, wage_systematic, draws):
     # Take the exponential of the disturbances
     exp_draws = np.exp(draws)
 
-    shape = (states.shape[0], draws.shape[1], NUM_CHOICES)
+    shape = (wage_systematic.shape[0], draws.shape[1], NUM_CHOICES)
     period_wages = np.full(shape, np.nan)
 
     # Calculate choice specific wages including productivity shock

--- a/soepy/python/shared/shared_auxiliary.py
+++ b/soepy/python/shared/shared_auxiliary.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-import numba
-
 from soepy.python.shared.shared_constants import NUM_CHOICES
 
 
@@ -25,7 +23,6 @@ def draw_disturbances(seed, shocks_cov, num_periods, num_draws):
     return draws
 
 
-@numba.jit(nopython=False)
 def calculate_utilities(model_params, states, covariates, draws):
     """Calculate period/flow utilities for all choices given state, period, and shocks.
 
@@ -81,7 +78,6 @@ def calculate_utilities(model_params, states, covariates, draws):
     return flow_utilities, consumption_utilities, period_wages, wage_systematic
 
 
-@numba.jit(nopython=False)
 def calculate_wage_systematic(model_params, states, covariates):
     """Calculate systematic wages, i.e., wages net of shock, for all states."""
 
@@ -103,7 +99,6 @@ def calculate_wage_systematic(model_params, states, covariates):
     return wage_systematic
 
 
-@numba.jit(nopython=False)
 def calculate_period_wages(model_params, states, wage_systematic, draws):
     """Calculate period wages for each choice including choice
     and period specific productivity shock.
@@ -126,7 +121,6 @@ def calculate_period_wages(model_params, states, wage_systematic, draws):
     return period_wages
 
 
-@numba.jit(nopython=False)
 def calculate_consumption_utilities(model_params, period_wages):
     """Calculate the first part of the period utilities related to consumption."""
 
@@ -152,7 +146,6 @@ def calculate_consumption_utilities(model_params, period_wages):
     return consumption_utilities
 
 
-@numba.jit(nopython=False)
 def calculate_total_utilities(model_params, consumption_utilities):
     """Calculate total period utilities for each of the choices."""
 

--- a/soepy/python/shared/shared_auxiliary.py
+++ b/soepy/python/shared/shared_auxiliary.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+import numba
+
 from soepy.python.shared.shared_constants import NUM_CHOICES
 
 
@@ -23,6 +25,7 @@ def draw_disturbances(seed, shocks_cov, num_periods, num_draws):
     return draws
 
 
+@numba.jit(nopython=False)
 def calculate_utilities(model_params, states, covariates, draws):
     """Calculate period/flow utilities for all choices given state, period, and shocks.
 
@@ -78,6 +81,7 @@ def calculate_utilities(model_params, states, covariates, draws):
     return flow_utilities, consumption_utilities, period_wages, wage_systematic
 
 
+@numba.jit(nopython=False)
 def calculate_wage_systematic(model_params, states, covariates):
     """Calculate systematic wages, i.e., wages net of shock, for all states."""
 
@@ -99,6 +103,7 @@ def calculate_wage_systematic(model_params, states, covariates):
     return wage_systematic
 
 
+@numba.jit(nopython=False)
 def calculate_period_wages(model_params, states, wage_systematic, draws):
     """Calculate period wages for each choice including choice
     and period specific productivity shock.
@@ -121,6 +126,7 @@ def calculate_period_wages(model_params, states, wage_systematic, draws):
     return period_wages
 
 
+@numba.jit(nopython=False)
 def calculate_consumption_utilities(model_params, period_wages):
     """Calculate the first part of the period utilities related to consumption."""
 
@@ -146,6 +152,7 @@ def calculate_consumption_utilities(model_params, period_wages):
     return consumption_utilities
 
 
+@numba.jit(nopython=False)
 def calculate_total_utilities(model_params, consumption_utilities):
     """Calculate total period utilities for each of the choices."""
 

--- a/soepy/python/shared/shared_auxiliary.py
+++ b/soepy/python/shared/shared_auxiliary.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+import numba
+
 from soepy.python.shared.shared_constants import NUM_CHOICES
 
 
@@ -121,6 +123,7 @@ def calculate_period_wages(model_params, states, wage_systematic, draws):
     return period_wages
 
 
+@numba.jit(nopython=True)
 def calculate_consumption_utilities(model_params, period_wages):
     """Calculate the first part of the period utilities related to consumption."""
 
@@ -129,18 +132,11 @@ def calculate_consumption_utilities(model_params, period_wages):
 
     # Calculate choice specific wages including productivity shock
     consumption_utilities = hours * period_wages
+    consumption_utilities[:, :, 0] = model_params.benefits
 
-    consumption_utilities[:, :, 0] = (
-        model_params.benefits ** model_params.mu
-    ) / model_params.mu
-
-    consumption_utilities[:, :, 1] = (
-        consumption_utilities[:, :, 1] ** model_params.mu
-    ) / model_params.mu
-
-    consumption_utilities[:, :, 2] = (
-        consumption_utilities[:, :, 2] ** model_params.mu
-    ) / model_params.mu
+    consumption_utilities = (
+        np.power(consumption_utilities, model_params.mu) / model_params.mu
+    )
 
     # Return function output
     return consumption_utilities

--- a/soepy/python/shared/shared_auxiliary.py
+++ b/soepy/python/shared/shared_auxiliary.py
@@ -33,9 +33,9 @@ def calculate_utilities(model_params, states, covariates, draws):
         (number of periods, agents, random draws, etc.) and coefficients to be
         estimated.
     states : np.ndarray
-        Array with shape (num_states, 6) containing period, experience in OCCUPATION A,
-        experience in OCCUPATION B, years of schooling, the lagged choice and the type
-        of the agent.
+        Array with shape (num_states, 5) containing period, years of schooling,
+        the lagged choice, the years of experience in part-time, and the
+        years of experience in full-time employment.
     covariates: np.ndarray
         Array with shape (num_states, number of covariates) containing all additional
         covariates, which depend only on the state space information.
@@ -57,7 +57,7 @@ def calculate_utilities(model_params, states, covariates, draws):
         Array with shape (num_states, num_draws, NUM_CHOICES) containing part
         of the utility related to consumption.
     flow_utilities : np.ndarray
-        Array with shape (num_states, num_draws, NUM_CHOICES) containing total
+        Array with dimensions (num_states, num_draws, NUM_CHOICES) containing total
         flow utility of each choice given error term draw at each state.
 
     """

--- a/soepy/python/shared/shared_constants.py
+++ b/soepy/python/shared/shared_constants.py
@@ -1,4 +1,5 @@
 # Set values of constants used across all modules here
 MISSING_INT = -99
+INVALID_FLOAT = -99.00
 NUM_COLUMNS_DATAFRAME = 14
 NUM_CHOICES = 3

--- a/soepy/python/shared/shared_constants.py
+++ b/soepy/python/shared/shared_constants.py
@@ -1,5 +1,5 @@
 # Set values of constants used across all modules here
 MISSING_INT = -99
-INVALID_FLOAT = -99.00
+INVALID_FLOAT = -99.0
 NUM_COLUMNS_DATAFRAME = 14
 NUM_CHOICES = 3

--- a/soepy/python/simulate/simulate_auxiliary.py
+++ b/soepy/python/simulate/simulate_auxiliary.py
@@ -3,10 +3,9 @@ import numpy as np
 from soepy.python.shared.shared_constants import NUM_COLUMNS_DATAFRAME
 from soepy.python.shared.shared_auxiliary import draw_disturbances
 from soepy.python.shared.shared_auxiliary import calculate_utilities
-from soepy.python.shared.shared_auxiliary import calculate_continuation_values
 
 
-def pyth_simulate(model_params, states, indexer, periods_emax, covariates):
+def pyth_simulate(model_params, states, indexer, emaxs, covariates):
     """Simulate agent experiences."""
 
     # Draw random initial conditions
@@ -73,25 +72,17 @@ def pyth_simulate(model_params, states, indexer, periods_emax, covariates):
             ]
 
             # Extract corresponding utilities
-            cuurent_flow_utilities = flow_utilities[current_state_index, i, :]
-            cuurent_cons_utilities = cons_utilities[current_state_index, i, :]
-            cuurent_period_wages = period_wages[current_state_index, i, :]
-            cuurent_wage_sys = wage_sys[current_state_index]
+            current_flow_utilities = flow_utilities[current_state_index, i, :]
+            current_cons_utilities = cons_utilities[current_state_index, i, :]
+            current_period_wages = period_wages[current_state_index, i, :]
+            current_wage_sys = wage_sys[current_state_index]
 
-            # Obtain continuation values for all choices
-            continuation_values = calculate_continuation_values(
-                model_params,
-                indexer,
-                period,
-                periods_emax,
-                educ_years_idx,
-                exp_p,
-                exp_f,
-            )
+            # Extract continuation values for all choices
+            continuation_values = emaxs[current_state_index, 0:3]
 
             # Calculate total values for all choices
             value_functions = (
-                cuurent_flow_utilities + model_params.delta * continuation_values
+                current_flow_utilities + model_params.delta * continuation_values
             )
 
             # Determine choice as option with highest choice specific value function
@@ -99,10 +90,10 @@ def pyth_simulate(model_params, states, indexer, periods_emax, covariates):
 
             # Record period experiences
             dataset[count, 3:4] = max_idx
-            dataset[count, 4:5] = cuurent_wage_sys
-            dataset[count, 5:8] = cuurent_period_wages[:]
-            dataset[count, 8:11] = cuurent_cons_utilities[:]
-            dataset[count, 11:14] = cuurent_flow_utilities[:]
+            dataset[count, 4:5] = current_wage_sys
+            dataset[count, 5:8] = current_period_wages[:]
+            dataset[count, 8:11] = current_cons_utilities[:]
+            dataset[count, 11:14] = current_flow_utilities[:]
 
             # Update state space component experience
             current_state[max_idx + 2] += 1

--- a/soepy/python/simulate/simulate_python.py
+++ b/soepy/python/simulate/simulate_python.py
@@ -13,7 +13,7 @@ def simulate(init_file_name):
     model_params = read_init_file(init_file_name)
 
     # Obtain model solution
-    states, indexer, emaxs, covariates = pyth_solve(model_params)
+    states, indexer, covariates, emaxs = pyth_solve(model_params)
 
     # Simulate agents experiences according to parameters in the model specification
     dataset = pyth_simulate(model_params, states, indexer, emaxs, covariates)

--- a/soepy/python/simulate/simulate_python.py
+++ b/soepy/python/simulate/simulate_python.py
@@ -13,10 +13,10 @@ def simulate(init_file_name):
     model_params = read_init_file(init_file_name)
 
     # Obtain model solution
-    states, indexer, periods_emax, covariates = pyth_solve(model_params)
+    states, indexer, emaxs, covariates = pyth_solve(model_params)
 
     # Simulate agents experiences according to parameters in the model specification
-    dataset = pyth_simulate(model_params, states, indexer, periods_emax, covariates)
+    dataset = pyth_simulate(model_params, states, indexer, emaxs, covariates)
 
     # Create fixed objects needed to record simulated data set to Pandas DataFrame
     # Define column labels

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -267,9 +267,7 @@ def pyth_backward_induction(model_params, states, indexer, flow_utilities):
 
             # Fill first block of elements in emaxs for the current period
             # corresponding to the continuation values
-            emaxs = get_continuation_values(
-                model_params, states_period, indexer, emaxs
-            )
+            emaxs = get_continuation_values(model_params, states_period, indexer, emaxs)
 
         # Extract current period information for current loop calculation
         emaxs_period = emaxs[np.where(states[:, 0] == period)]

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -327,6 +327,7 @@ def get_continuation_values(model_params, states_subset, indexer, emaxs):
     return emaxs
 
 
+@numba.jit(nopython=True)
 def construct_emax(model_params, flow_utilities_period, emaxs_period):
     """Simulate expected maximum utility for a given distribution of the unobservable.
 
@@ -369,7 +370,7 @@ def construct_emax(model_params, flow_utilities_period, emaxs_period):
     emax_period = np.zeros(num_states_period)
 
     for i in range(model_params.num_draws_emax):
-        current_max_value_function = np.repeat(INVALID_FLOAT, num_states_period)
+        current_max_value_function = np.full((num_states_period, ), INVALID_FLOAT)
 
         for j in range(NUM_CHOICES):
             value_function_choice = (

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -284,6 +284,7 @@ def pyth_backward_induction(model_params, states, indexer, flow_utilities):
     return emaxs
 
 
+@numba.njit(nogil=True)
 def get_continuation_values(model_params, states_subset, indexer, emaxs):
     """Obtain continuation values for each of the choices at each state
     of the period currently reached by the parent loop.

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -79,9 +79,9 @@ def pyth_create_state_space(model_params):
     Returns
     -------
     states : np.ndarray
-        Array with shape (num_states, 6) containing period, experience in OCCUPATION A,
-        experience in OCCUPATION B, years of schooling, the lagged choice and the type
-        of the agent.
+        Array with shape (num_states, 5) containing period, years of schooling,
+        the lagged choice, the years of experience in part-time, and the
+        years of experience in full-time employment.
     indexer : np.ndarray
         A matrix where each dimension represents a characteristic of the state space.
         Switching from one state is possible via incrementing appropriate indices by 1.

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -5,15 +5,15 @@ from soepy.python.shared.shared_constants import MISSING_INT, NUM_CHOICES
 
 
 def construct_covariates(states):
-    """Construct a matrix of covariates
+    """Construct a matrix of all the covariates
     that depend only on the state space.
 
     Parameters
     ---------
     states : np.ndarray
-        Array with shape (num_states, 6) containing period, experience in OCCUPATION A,
-        experience in OCCUPATION B, years of schooling, the lagged choice and the type
-        of the agent.
+        Array with shape (num_states, 5) containing period, years of education,
+        the lagged choice, years of experience in part-time and in full-time
+         employment of the agent.
 
     Returns
     -------
@@ -66,14 +66,9 @@ def pyth_create_state_space(model_params):
 
     Parameters
     ----------
-    model_params.num_periods : int
-        Number of periods in the state space.
-    model_params.educ_range : int
-        Range of initial condition years of education in the (simulated) sample.
-    NUM_CHOICES : int
-        Number of choices agents have in each period.
-    educ_min : int
-        Minimum number of years of education in the simulated sample.
+    model_params.num_periods : namedtuple
+        Namedtuple containing all information relevant for running a simulation.
+        Includes parameters, dimensions, information on initial conditions, etc.
 
     Returns
     -------
@@ -87,6 +82,7 @@ def pyth_create_state_space(model_params):
 
     Examples
     --------
+    >>> from collections import namedtuple
     >>> model_params = namedtuple("model_params", "num_periods educ_range educ_min")
     >>> model_params = model_params(10, 3, 10)
     >>> NUM_CHOICES = 3
@@ -125,10 +121,10 @@ def pyth_create_state_space(model_params):
             if educ_years > period:
                 continue
 
-            # Loop over all admissible years of experience accumulated in part-time
+            # Loop over all admissible years of experience accumulated in full-time
             for exp_f in range(model_params.num_periods):
 
-                # Loop over all admissible years of experience accumulated in full-time
+                # Loop over all admissible years of experience accumulated in part-time
                 for exp_p in range(model_params.num_periods):
 
                     # The accumulation of experience cannot exceed time elapsed
@@ -181,7 +177,7 @@ def pyth_create_state_space(model_params):
                                 continue
 
                             # If an individual has always been employed,
-                            # she cannot have nonemployment (0) as lagged choice
+                            # she cannot have non-employment (0) as lagged choice
                             if (choice_lagged == 0) and (
                                 exp_f + exp_p == period - educ_years
                             ):
@@ -341,10 +337,8 @@ def construct_emax(delta, flow_utilities_period, emaxs_period, emax_period):
 
     Parameters
     ----------
-    model_params : namedtuple
-        Contains all parameters of the model including information on dimensions
-        (number of periods, agents, random draws, etc.) and coefficients to be
-        estimated.
+    delta : int
+        Dynamic discount factor.
     flow_utilities_period : np.ndarray
         Array with dimensions (number of states in period, num_draws, NUM_CHOICES)
         containing total flow utility of each choice given error term draw

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numba
 
-from soepy.python.shared.shared_constants import MISSING_INT, NUM_CHOICES
+from soepy.python.shared.shared_constants import MISSING_INT, NUM_CHOICES, INVALID_FLOAT
 
 
 def construct_covariates(states):
@@ -364,7 +364,7 @@ def construct_emax(delta, flow_utilities_period, emaxs_period, emax_period):
     num_draws, num_choices = flow_utilities_period.shape
 
     for i in range(num_draws):
-        current_max_value_function = -99.0
+        current_max_value_function = INVALID_FLOAT
 
         for j in range(num_choices):
             value_function_choice = (

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -66,7 +66,7 @@ def pyth_create_state_space(model_params):
 
     Parameters
     ----------
-    model_params.num_periods : namedtuple
+    model_params: namedtuple
         Namedtuple containing all information relevant for running a simulation.
         Includes parameters, dimensions, information on initial conditions, etc.
 

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -370,7 +370,7 @@ def construct_emax(model_params, flow_utilities_period, emaxs_period):
     emax_period = np.zeros(num_states_period)
 
     for i in range(model_params.num_draws_emax):
-        current_max_value_function = np.full((num_states_period, ), INVALID_FLOAT)
+        current_max_value_function = np.full((num_states_period,), INVALID_FLOAT)
 
         for j in range(NUM_CHOICES):
             value_function_choice = (

--- a/soepy/python/solve/solve_auxiliary.py
+++ b/soepy/python/solve/solve_auxiliary.py
@@ -1,8 +1,7 @@
 import numpy as np
 import numba
 
-from soepy.python.shared.shared_constants import MISSING_INT, NUM_CHOICES
-from soepy.python.shared.shared_auxiliary import calculate_continuation_values
+from soepy.python.shared.shared_constants import MISSING_INT, NUM_CHOICES, INVALID_FLOAT
 
 
 def construct_covariates(states):
@@ -220,86 +219,168 @@ def pyth_create_state_space(model_params):
     return states, indexer
 
 
-def pyth_backward_induction(model_params, states, indexer, covariates, flow_utilities):
-    """Obtain the value function maximum values
-    for all admissible states and periods in a backward induction procedure.
+def pyth_backward_induction(model_params, states, indexer, flow_utilities):
+    """Get expected maximum value function at every state space point.
+
+    Parameters
+    ----------
+    model_params : namedtuple
+        Contains all parameters of the model including information on dimensions
+        (number of periods, agents, random draws, etc.) and coefficients to be
+        estimated.
+    states : np.ndarray
+        Array with shape (num_states, 5) containing period, years of schooling,
+        the lagged choice, the years of experience in part-time, and the
+        years of experience in full-time employment.
+    indexer : np.ndarray
+        Array where each dimension represents a componenet of the state space.
+        :data:`states[k]` returns the values of the state space components
+        at state :data:`k`. Indexing :data:`indexer` by the same state space
+        component values returns :data:`k`.
+    flow_utilities : np.ndarray
+        Array with dimensions (num_states, num_draws, NUM_CHOICES) containing total
+        flow utility of each choice given error term draw at each state.
+
+    Returns
+    -------
+    emaxs : np.ndarray
+        An array of dimension (num_states, num choices + 1). The object's rows contain
+        the continuation values of each choice at the specific state space points
+        as its first elements. The last row element corresponds to the maximum
+        expected value function of the state.
     """
 
-    # Initialize container for the final result,
-    # maximal value function per state:
-    periods_emax = np.full(states.shape[0], np.nan)
+    emaxs = np.zeros((states.shape[0], NUM_CHOICES + 1))
 
-    # Loop over all periods
-    for k in reversed(range(states.shape[0])):
+    # Loop backwards over all periods
+    for period in reversed(range(model_params.num_periods)):
 
-        # Construct additional education information
-        educ_level = covariates[k, :]
-        educ_years_idx = np.where(educ_level == np.max(educ_level))[0]
+        # Extract period information
+        states_period = states[np.where(states[:, 0] == period)]  # as slice
+        flow_utilities_period = flow_utilities[np.where(states[:, 0] == period)]
 
-        # Integrate out the error term
-        emax = construct_emax(
-            model_params,
-            k,
-            flow_utilities,
-            educ_years_idx,
-            states,
-            indexer,
-            periods_emax,
-        )
+        # Continuation value calculation not performed for last period
+        # since continuation values are known to be zero
+        if period == model_params.num_periods - 1:
+            pass
+        else:
 
-        # Record function output
-        periods_emax[k] = emax
+            # Fill first block of elements in emaxs for the current period
+            # corresponding to the continuation values
+            emaxs = get_continuation_values(
+                model_params, states_period, indexer, emaxs
+            )  # njit
 
-    # Return function output
-    return periods_emax
+        # Extract current period information for current loop calculation
+        emaxs_period = emaxs[np.where(states[:, 0] == period)]
+
+        # Calculate emax for current period reached by the loop
+        emax_period = construct_emax(
+            model_params, flow_utilities_period, emaxs_period
+        )  # guvectorize
+        emaxs_period[:, 3] = emax_period
+        emaxs[np.where(states[:, 0] == period)] = emaxs_period
+
+    return emaxs
 
 
-def construct_emax(
-    model_params, k, flow_utilities, educ_years_idx, states, indexer, periods_emax
-):
-    """Integrate out the error terms in a Monte Carlo simulation procedure
-    to obtain value function maximum values for each period and state.
+def get_continuation_values(model_params, states_subset, indexer, emaxs):
+    """Obtain continuation values for each of the choices at each state
+    of the period currently reached by the parent loop.
+
+    This function takes a parent node and looks up the continuation values
+    of each of the available choices. It takes the entire block of
+    data:`emaxs` corresponding to the period and fills in the first block
+    of elements corresponding to the continuation values.
+    The continuation value of each choice is the expected maximum value
+    function of the next period's state if the particular choice was
+    taken this period. The expected maximum value function values are
+    contained as the last element of the data:`emaxs` row of next
+    period's state.
+
+    Warning
+    -------
+    This function must be extremely performant as the lookup is done for each state in a
+    state space (except for states in the last period) for each evaluation of the
+    optimization of parameters.
     """
+    for i in range(states_subset.shape[0]):
+        # Unpack parent state and get index
+        period, educ_years, choice_lagged, exp_p, exp_f = states_subset[i]
+        k_parent = indexer[
+            period, educ_years - model_params.educ_min, choice_lagged, exp_p, exp_f
+        ]
 
-    # Initialize container for sum of value function maximum values
-    # over all error term draws for the period and state
-    emax = 0.0
+        # Choice: Non-employment
+        k = indexer[period + 1, educ_years - model_params.educ_min, 0, exp_p, exp_f]
+        emaxs[k_parent, 0] = emaxs[k, 3]
 
-    # Loop over all error term draws
-    # for the period and state currently reached by the parent loop
+        # Choice: Part-time
+        k = indexer[period + 1, educ_years - model_params.educ_min, 1, exp_p + 1, exp_f]
+        emaxs[k_parent, 1] = emaxs[k, 3]
+
+        # Choice: Full-time
+        k = indexer[period + 1, educ_years - model_params.educ_min, 2, exp_p, exp_f + 1]
+        emaxs[k_parent, 2] = emaxs[k, 3]
+
+    return emaxs
+
+
+def construct_emax(model_params, flow_utilities_period, emaxs_period):
+    """Simulate expected maximum utility for a given distribution of the unobservable.
+
+    The function calculates the maximum expected value function over the distribution
+    of the error term at each state space point in the period currently reached by the
+    parent loop. The expectation calculation is performed via `Monte Carlo integration`_.
+    The goal is to approximate an integral by evaluating the integrand at randomly chosen
+    points. In this setting, one wants to approximate the expected maximum utility of
+    the current state.
+
+    Parameters
+    ----------
+    model_params : namedtuple
+        Contains all parameters of the model including information on dimensions
+        (number of periods, agents, random draws, etc.) and coefficients to be
+        estimated.
+    flow_utilities_period : np.ndarray
+        Array with dimensions (number of states in period, num_draws, NUM_CHOICES)
+        containing total flow utility of each choice given error term draw
+        at each state.
+    emaxs_period : np.ndarray
+        An array of dimension (num. states in period, num choices + 1).
+        The object's rows contain the continuation values of each choice at the specific
+        state space points as its first elements. The last row element corresponds
+        to the maximum expected value function of the state. This column is
+        full of zeros for the input object.
+
+    Returns
+    -------
+    emax_period : np.array
+        Expected maximum value function of the current state space point.
+        Array of length number of states in the current period. The vector
+        corresponds to the second block of values in the data:`emaxs` object.
+
+    .. _Monte Carlo integration:
+        https://en.wikipedia.org/wiki/Monte_Carlo_integration
+
+    """
+    num_states_period = emaxs_period.shape[0]
+    emax_period = np.zeros(num_states_period)
+
     for i in range(model_params.num_draws_emax):
+        current_max_value_function = np.repeat(INVALID_FLOAT, num_states_period)
 
-        # Extract relevant state space components
-        period, _, _, exp_p, exp_f = states[k, :]
+        for j in range(NUM_CHOICES):
+            value_function_choice = (
+                flow_utilities_period[:, i, j] + model_params.delta * emaxs_period[:, j]
+            )
 
-        # Calculate flow utility at current period, state, and draw
-        current_flow_utilities = flow_utilities[k, i, :]
+            for k in range(num_states_period):
+                if value_function_choice[k] > current_max_value_function[k]:
+                    current_max_value_function[k] = value_function_choice[k]
 
-        # Obtain continuation values for all choices
-        continuation_values = calculate_continuation_values(
-            model_params, indexer, period, periods_emax, educ_years_idx, exp_p, exp_f
-        )
+        emax_period += current_max_value_function
 
-        # Calculate choice specific value functions
-        value_functions = (
-            current_flow_utilities + model_params.delta * continuation_values
-        )
+    emax_period /= model_params.num_draws_emax
 
-        # Obtain highest value function value among the available choices. If above
-        # draws were the true shocks, maximum is the the current period value function
-        # value. It is the sum the flow utility and next periods value function given an
-        # optimal decision in the future and an optimal choice in the current period.
-        maximum = max(value_functions)
-
-        # Add to sum over all draws
-        emax += maximum
-
-        # End loop
-
-    # Average over the number of draws
-    emax = emax / model_params.num_draws_emax
-
-    # Thus, we have integrated out the error term
-
-    # Return function output
-    return emax
+    return emax_period

--- a/soepy/python/solve/solve_python.py
+++ b/soepy/python/solve/solve_python.py
@@ -24,9 +24,7 @@ def pyth_solve(model_params):
     # Solve the model in a backward induction procedure
     # Error term for continuation values is integrated out
     # numerically in a Monte Carlo procedure
-    periods_emax = pyth_backward_induction(
-        model_params, states, indexer, covariates, flow_utilities
-    )
+    emaxs = pyth_backward_induction(model_params, states, indexer, flow_utilities)
 
     # Return function output
-    return states, indexer, periods_emax, covariates
+    return states, indexer, emaxs, covariates

--- a/soepy/python/solve/solve_python.py
+++ b/soepy/python/solve/solve_python.py
@@ -6,7 +6,39 @@ from soepy.python.solve.solve_auxiliary import pyth_backward_induction
 
 
 def pyth_solve(model_params):
-    """Solve the model by backward induction."""
+    """Solve the model by backward induction.
+
+    The solution routine performs four key operations:
+    - create all nodes (state space points) of the decision tree (state space)
+    that the agents might possibly reach.
+    - create covariates that depend on the state space components at every
+    state space point.
+    - calculate the instantaneous/flow utilities for each possible choice at every
+    state space point
+    - calculate the continuation values for each choice at every
+    state space point.
+
+    Parameters
+    __________
+    model_params : namedtuple
+        Namedtuple containing all information relevant for running a simulation.
+        Includes parameters, dimensions, information on initial conditions, etc.
+
+    Returns
+    _______
+    states : np.ndarray
+        Array with shape (num_states, 5) containing period, years of schooling,
+        the lagged choice, the years of experience in part-time, and the
+        years of experience in full-time employment.
+    indexer : np.ndarray
+        A matrix where each dimension represents a characteristic of the state space.
+        Switching from one state is possible via incrementing appropriate indices by 1.
+    covariates : np.ndarray
+        Array with shape (num_states, number of covariates) containing all additional
+        covariates, which depend only on the state space information.
+    emax_period : np.array
+        Expected maximum value function of the current state space point.
+    """
 
     # Create all necessary grids and objects related to the state space
     states, indexer = pyth_create_state_space(model_params)
@@ -27,4 +59,4 @@ def pyth_solve(model_params):
     emaxs = pyth_backward_induction(model_params, states, indexer, flow_utilities)
 
     # Return function output
-    return states, indexer, emaxs, covariates
+    return states, indexer, covariates, emaxs

--- a/soepy/test/random_init.py
+++ b/soepy/test/random_init.py
@@ -22,7 +22,7 @@ def random_init(constr=None):
         educ_max = 12
 
     if "EDUC_MIN" in constr.keys():
-        educ_max = constr["EDUC_MIN"]
+        educ_min = constr["EDUC_MIN"]
     else:
         educ_min = 10
 

--- a/soepy/test/test_unit.py
+++ b/soepy/test/test_unit.py
@@ -22,7 +22,7 @@ def test1():
     """This test ensures that the columns of the output data frame correspond to the
     function output values.
     """
-    for _ in range(100):
+    for _ in range(10):
         constr = {"EDUC_MAX": 10, "AGENTS": 1, "PERIODS": 1}
         random_init(constr)
         model_params = read_init_file("test.soepy.yml")


### PR DESCRIPTION
In this PR we aim at speeding up soepy further by applying numba and guvectorize to the backward induction step.

- [X] rewrite periods_emax and continuation_values objects to emaxs
- [x] apply njit to the get_continuation_values function
- [x] apply guvectorize to the construct_emax function
- [x] issue #2 
- [x] issue #53 
- [x] issue #54 